### PR TITLE
Fix Lantern Blocks and Lit Redstone Lamps Tile Drops

### DIFF
--- a/src/main/java/com/brand/blockus/blocks/Light/LightBlockBase.java
+++ b/src/main/java/com/brand/blockus/blocks/Light/LightBlockBase.java
@@ -17,7 +17,7 @@ import net.minecraft.util.registry.Registry;
 public class LightBlockBase extends Block {
 
 	public LightBlockBase(String name, float hardness, float resistance, Material material, BlockSoundGroup sound, ItemGroup itemgroup, int lightlevel, MaterialColor color) {
-		super(FabricBlockSettings.of(material, color).sounds(sound).lightLevel(lightlevel).requiresTool().strength(hardness, resistance));
+		super(FabricBlockSettings.of(material, color).sounds(sound).lightLevel(lightlevel).breakByTool(FabricToolTags.PICKAXES, 1).strength(hardness, resistance));
 		Registry.register(Registry.BLOCK, new Identifier(Blockus.MOD_ID, name), this);
 		Registry.register(Registry.ITEM,new Identifier(Blockus.MOD_ID, name), new BlockItem(this, new Item.Settings().maxCount(64).group(itemgroup)));
 	}

--- a/src/main/java/com/brand/blockus/blocks/Light/LitRedstoneLampBase.java
+++ b/src/main/java/com/brand/blockus/blocks/Light/LitRedstoneLampBase.java
@@ -1,0 +1,24 @@
+package com.brand.blockus.blocks.Light;
+
+import com.brand.blockus.Blockus;
+
+import net.fabricmc.fabric.api.object.builder.v1.block.FabricBlockSettings;
+import net.minecraft.block.Block;
+import net.minecraft.block.Material;
+import net.minecraft.block.MaterialColor;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemGroup;
+import net.minecraft.sound.BlockSoundGroup;
+import net.minecraft.item.BlockItem;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.registry.Registry;
+
+public class LitRedstoneLampBase extends Block {
+
+	public LitRedstoneLampBase(String name, float hardness, float resistance, Material material, BlockSoundGroup sound, ItemGroup itemgroup, int lightlevel, MaterialColor color) {
+		super(FabricBlockSettings.of(material, color).sounds(sound).lightLevel(lightlevel).strength(hardness, resistance));
+		Registry.register(Registry.BLOCK, new Identifier(Blockus.MOD_ID, name), this);
+		Registry.register(Registry.ITEM,new Identifier(Blockus.MOD_ID, name), new BlockItem(this, new Item.Settings().maxCount(64).group(itemgroup)));
+	}
+	
+}

--- a/src/main/java/com/brand/blockus/content/Other.java
+++ b/src/main/java/com/brand/blockus/content/Other.java
@@ -39,10 +39,10 @@ public class Other {
     public static final FallingRedstoneBase REDSTONE_SAND = new FallingRedstoneBase("redstone_sand", 2.0f, 6.0f);
     public static final IronGateBase IRON_GATE = new IronGateBase("iron_gate", 5.0f, 5.0f);
     public static final IronGateBase GOLDEN_GATE = new IronGateBase("golden_gate", 5.0f, 5.0f);
-    public static final LightBlockBase LANTERN_BLOCK = new LightBlockBase("lantern_block", 0.3f, 0.3f, Material.METAL, BlockSoundGroup.LANTERN, Blockus.BLOCKUS_BUILDING_BLOCKS, 15, MaterialColor.IRON);
+    public static final LightBlockBase LANTERN_BLOCK = new LightBlockBase("lantern_block", 3.5f, 5.0f, Material.METAL, BlockSoundGroup.LANTERN, Blockus.BLOCKUS_BUILDING_BLOCKS, 15, MaterialColor.IRON);
     public static final PortalCubeBlock WEIGHT_STORAGE_CUBE= new PortalCubeBlock("weight_storage_cube", 0.1f, 6.0f);
     public static final PortalCubeBlock COMPANION_CUBE = new PortalCubeBlock("companion_cube", 0.1f, 6.0f);
-    public static final LightBlockBase SOUL_LANTERN_BLOCK = new LightBlockBase("soul_lantern_block", 0.3f, 0.3f, Material.METAL,BlockSoundGroup.LANTERN, Blockus.BLOCKUS_BUILDING_BLOCKS, 10, MaterialColor.IRON);
+    public static final LightBlockBase SOUL_LANTERN_BLOCK = new LightBlockBase("soul_lantern_block", 3.5f, 5.0f, Material.METAL,BlockSoundGroup.LANTERN, Blockus.BLOCKUS_BUILDING_BLOCKS, 10, MaterialColor.IRON);
     public static final CarvedPumpkinBlockBase SOUL_O_LANTERN = new CarvedPumpkinBlockBase("soul_o_lantern", 1.0f, 1.0f);
     public static final ChainBlockBase GOLDEN_CHAIN = new ChainBlockBase("golden_chain", 5.0F, 6.0F);
 	public static final PaneBase GOLDEN_BARS = new PaneBase("golden_bars", 5.0F, 6.0f, Material.METAL, BlockSoundGroup.METAL);

--- a/src/main/java/com/brand/blockus/content/RedstoneLamps.java
+++ b/src/main/java/com/brand/blockus/content/RedstoneLamps.java
@@ -1,9 +1,8 @@
 package com.brand.blockus.content;
 
 import com.brand.blockus.Blockus;
-import com.brand.blockus.blocks.Light.LightBlockBase;
+import com.brand.blockus.blocks.Light.LitRedstoneLampBase;
 import com.brand.blockus.blocks.Light.RedstoneLampBase;
-
 import net.minecraft.block.Material;
 import net.minecraft.block.MaterialColor;
 import net.minecraft.sound.BlockSoundGroup;
@@ -26,21 +25,21 @@ public static final RedstoneLampBase BROWN_REDSTONE_LAMP = new RedstoneLampBase(
 public static final RedstoneLampBase GREEN_REDSTONE_LAMP = new RedstoneLampBase("green_redstone_lamp", 0.3f, 0.3f);
 public static final RedstoneLampBase RED_REDSTONE_LAMP = new RedstoneLampBase("red_redstone_lamp", 0.3f, 0.3f);
 
-public static final LightBlockBase REDSTONE_LAMP_LIT = new LightBlockBase("redstone_lamp_lit", 0.3f, 0.3f, Material.REDSTONE_LAMP, BlockSoundGroup.GLASS, Blockus.BLOCKUS_DECORATIONS, 15, MaterialColor.CLEAR);
-public static final LightBlockBase WHITE_REDSTONE_LAMP_LIT = new LightBlockBase("white_redstone_lamp_lit", 0.3f, 0.3f, Material.REDSTONE_LAMP, BlockSoundGroup.GLASS, Blockus.BLOCKUS_DECORATIONS, 15, MaterialColor.CLEAR);
-public static final LightBlockBase ORANGE_REDSTONE_LAMP_LIT = new LightBlockBase("orange_redstone_lamp_lit", 0.3f, 0.3f, Material.REDSTONE_LAMP, BlockSoundGroup.GLASS, Blockus.BLOCKUS_DECORATIONS, 15, MaterialColor.CLEAR);
-public static final LightBlockBase MAGENTA_REDSTONE_LAMP_LIT = new LightBlockBase("magenta_redstone_lamp_lit", 0.3f, 0.3f, Material.REDSTONE_LAMP, BlockSoundGroup.GLASS, Blockus.BLOCKUS_DECORATIONS, 15, MaterialColor.CLEAR);
-public static final LightBlockBase LIGHT_BLUE_REDSTONE_LAMP_LIT = new LightBlockBase("light_blue_redstone_lamp_lit", 0.3f, 0.3f, Material.REDSTONE_LAMP, BlockSoundGroup.GLASS, Blockus.BLOCKUS_DECORATIONS, 15, MaterialColor.CLEAR);
-public static final LightBlockBase YELLOW_REDSTONE_LAMP_LIT = new LightBlockBase("yellow_redstone_lamp_lit", 0.3f, 0.3f, Material.REDSTONE_LAMP, BlockSoundGroup.GLASS, Blockus.BLOCKUS_DECORATIONS, 15, MaterialColor.CLEAR);
-public static final LightBlockBase LIME_REDSTONE_LAMP_LIT = new LightBlockBase("lime_redstone_lamp_lit", 0.3f, 0.3f, Material.REDSTONE_LAMP, BlockSoundGroup.GLASS, Blockus.BLOCKUS_DECORATIONS, 15, MaterialColor.CLEAR);
-public static final LightBlockBase PINK_REDSTONE_LAMP_LIT = new LightBlockBase("pink_redstone_lamp_lit", 0.3f, 0.3f, Material.REDSTONE_LAMP, BlockSoundGroup.GLASS, Blockus.BLOCKUS_DECORATIONS, 15, MaterialColor.CLEAR);
-public static final LightBlockBase GRAY_REDSTONE_LAMP_LIT = new LightBlockBase("gray_redstone_lamp_lit", 0.3f, 0.3f, Material.REDSTONE_LAMP, BlockSoundGroup.GLASS, Blockus.BLOCKUS_DECORATIONS, 15, MaterialColor.CLEAR);
-public static final LightBlockBase LIGHT_GRAY_REDSTONE_LAMP_LIT = new LightBlockBase("light_gray_redstone_lamp_lit", 0.3f, 0.3f, Material.REDSTONE_LAMP, BlockSoundGroup.GLASS, Blockus.BLOCKUS_DECORATIONS, 15, MaterialColor.CLEAR);
-public static final LightBlockBase CYAN_REDSTONE_LAMP_LIT = new LightBlockBase("cyan_redstone_lamp_lit", 0.3f, 0.3f, Material.REDSTONE_LAMP, BlockSoundGroup.GLASS, Blockus.BLOCKUS_DECORATIONS, 15, MaterialColor.CLEAR);
-public static final LightBlockBase PURPLE_REDSTONE_LAMP_LIT = new LightBlockBase("purple_redstone_lamp_lit", 0.3f, 0.3f, Material.REDSTONE_LAMP, BlockSoundGroup.GLASS, Blockus.BLOCKUS_DECORATIONS, 15, MaterialColor.CLEAR);
-public static final LightBlockBase BLUE_REDSTONE_LAMP_LIT = new LightBlockBase("blue_redstone_lamp_lit", 0.3f, 0.3f, Material.REDSTONE_LAMP, BlockSoundGroup.GLASS, Blockus.BLOCKUS_DECORATIONS, 15, MaterialColor.CLEAR);
-public static final LightBlockBase BROWN_REDSTONE_LAMP_LIT = new LightBlockBase("brown_redstone_lamp_lit", 0.3f, 0.3f, Material.REDSTONE_LAMP, BlockSoundGroup.GLASS, Blockus.BLOCKUS_DECORATIONS, 15, MaterialColor.CLEAR);
-public static final LightBlockBase GREEN_REDSTONE_LAMP_LIT = new LightBlockBase("green_redstone_lamp_lit", 0.3f, 0.3f, Material.REDSTONE_LAMP, BlockSoundGroup.GLASS, Blockus.BLOCKUS_DECORATIONS, 15, MaterialColor.CLEAR);
-public static final LightBlockBase RED_REDSTONE_LAMP_LIT = new LightBlockBase("red_redstone_lamp_lit", 0.3f, 0.3f, Material.REDSTONE_LAMP, BlockSoundGroup.GLASS, Blockus.BLOCKUS_DECORATIONS, 15, MaterialColor.CLEAR);
+public static final LitRedstoneLampBase REDSTONE_LAMP_LIT = new LitRedstoneLampBase("redstone_lamp_lit", 0.3f, 0.3f, Material.REDSTONE_LAMP, BlockSoundGroup.GLASS, Blockus.BLOCKUS_DECORATIONS, 15, MaterialColor.CLEAR);
+public static final LitRedstoneLampBase WHITE_REDSTONE_LAMP_LIT = new LitRedstoneLampBase("white_redstone_lamp_lit", 0.3f, 0.3f, Material.REDSTONE_LAMP, BlockSoundGroup.GLASS, Blockus.BLOCKUS_DECORATIONS, 15, MaterialColor.CLEAR);
+public static final LitRedstoneLampBase ORANGE_REDSTONE_LAMP_LIT = new LitRedstoneLampBase("orange_redstone_lamp_lit", 0.3f, 0.3f, Material.REDSTONE_LAMP, BlockSoundGroup.GLASS, Blockus.BLOCKUS_DECORATIONS, 15, MaterialColor.CLEAR);
+public static final LitRedstoneLampBase MAGENTA_REDSTONE_LAMP_LIT = new LitRedstoneLampBase("magenta_redstone_lamp_lit", 0.3f, 0.3f, Material.REDSTONE_LAMP, BlockSoundGroup.GLASS, Blockus.BLOCKUS_DECORATIONS, 15, MaterialColor.CLEAR);
+public static final LitRedstoneLampBase LIGHT_BLUE_REDSTONE_LAMP_LIT = new LitRedstoneLampBase("light_blue_redstone_lamp_lit", 0.3f, 0.3f, Material.REDSTONE_LAMP, BlockSoundGroup.GLASS, Blockus.BLOCKUS_DECORATIONS, 15, MaterialColor.CLEAR);
+public static final LitRedstoneLampBase YELLOW_REDSTONE_LAMP_LIT = new LitRedstoneLampBase("yellow_redstone_lamp_lit", 0.3f, 0.3f, Material.REDSTONE_LAMP, BlockSoundGroup.GLASS, Blockus.BLOCKUS_DECORATIONS, 15, MaterialColor.CLEAR);
+public static final LitRedstoneLampBase LIME_REDSTONE_LAMP_LIT = new LitRedstoneLampBase("lime_redstone_lamp_lit", 0.3f, 0.3f, Material.REDSTONE_LAMP, BlockSoundGroup.GLASS, Blockus.BLOCKUS_DECORATIONS, 15, MaterialColor.CLEAR);
+public static final LitRedstoneLampBase PINK_REDSTONE_LAMP_LIT = new LitRedstoneLampBase("pink_redstone_lamp_lit", 0.3f, 0.3f, Material.REDSTONE_LAMP, BlockSoundGroup.GLASS, Blockus.BLOCKUS_DECORATIONS, 15, MaterialColor.CLEAR);
+public static final LitRedstoneLampBase GRAY_REDSTONE_LAMP_LIT = new LitRedstoneLampBase("gray_redstone_lamp_lit", 0.3f, 0.3f, Material.REDSTONE_LAMP, BlockSoundGroup.GLASS, Blockus.BLOCKUS_DECORATIONS, 15, MaterialColor.CLEAR);
+public static final LitRedstoneLampBase LIGHT_GRAY_REDSTONE_LAMP_LIT = new LitRedstoneLampBase("light_gray_redstone_lamp_lit", 0.3f, 0.3f, Material.REDSTONE_LAMP, BlockSoundGroup.GLASS, Blockus.BLOCKUS_DECORATIONS, 15, MaterialColor.CLEAR);
+public static final LitRedstoneLampBase CYAN_REDSTONE_LAMP_LIT = new LitRedstoneLampBase("cyan_redstone_lamp_lit", 0.3f, 0.3f, Material.REDSTONE_LAMP, BlockSoundGroup.GLASS, Blockus.BLOCKUS_DECORATIONS, 15, MaterialColor.CLEAR);
+public static final LitRedstoneLampBase PURPLE_REDSTONE_LAMP_LIT = new LitRedstoneLampBase("purple_redstone_lamp_lit", 0.3f, 0.3f, Material.REDSTONE_LAMP, BlockSoundGroup.GLASS, Blockus.BLOCKUS_DECORATIONS, 15, MaterialColor.CLEAR);
+public static final LitRedstoneLampBase BLUE_REDSTONE_LAMP_LIT = new LitRedstoneLampBase("blue_redstone_lamp_lit", 0.3f, 0.3f, Material.REDSTONE_LAMP, BlockSoundGroup.GLASS, Blockus.BLOCKUS_DECORATIONS, 15, MaterialColor.CLEAR);
+public static final LitRedstoneLampBase BROWN_REDSTONE_LAMP_LIT = new LitRedstoneLampBase("brown_redstone_lamp_lit", 0.3f, 0.3f, Material.REDSTONE_LAMP, BlockSoundGroup.GLASS, Blockus.BLOCKUS_DECORATIONS, 15, MaterialColor.CLEAR);
+public static final LitRedstoneLampBase GREEN_REDSTONE_LAMP_LIT = new LitRedstoneLampBase("green_redstone_lamp_lit", 0.3f, 0.3f, Material.REDSTONE_LAMP, BlockSoundGroup.GLASS, Blockus.BLOCKUS_DECORATIONS, 15, MaterialColor.CLEAR);
+public static final LitRedstoneLampBase RED_REDSTONE_LAMP_LIT = new LitRedstoneLampBase("red_redstone_lamp_lit", 0.3f, 0.3f, Material.REDSTONE_LAMP, BlockSoundGroup.GLASS, Blockus.BLOCKUS_DECORATIONS, 15, MaterialColor.CLEAR);
 
 }


### PR DESCRIPTION
This does many things:

- Allows Lantern Blocks and Lit Redstone Lamps to drop tiles
- Changes Lantern Blocks to match vanilla hardness, mining behavior,, and adds some blast resistance since it's a full block not a small lantern
- Adds a dedicated base for Lit Redstone Lamps to retain their vanilla breaking behavior