### PR TITLE
Add sturdy stone

### DIFF
--- a/src/main/java/com/brand/blockus/blocks/SturdyStoneBlock.java
+++ b/src/main/java/com/brand/blockus/blocks/SturdyStoneBlock.java
@@ -1,0 +1,27 @@
+package com.brand.blockus.blocks;
+
+import com.brand.blockus.Blockus;
+
+import net.fabricmc.fabric.api.object.builder.v1.block.FabricBlockSettings;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
+import net.minecraft.block.piston.PistonBehavior;
+import net.minecraft.item.BlockItem;
+import net.minecraft.item.Item;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.Rarity;
+import net.minecraft.util.registry.Registry;
+
+public class SturdyStoneBlock extends Block {
+	public SturdyStoneBlock(String name) {
+		super(FabricBlockSettings.copy(Blocks.STONE));
+		Registry.register(Registry.BLOCK, new Identifier(Blockus.MOD_ID, name), this);
+		Registry.register(Registry.ITEM,new Identifier(Blockus.MOD_ID, name), new BlockItem(this, new Item.Settings().group(Blockus.BLOCKUS_BUILDING_BLOCKS)));
+	}
+
+	@Override
+	public PistonBehavior getPistonBehavior(BlockState state) {
+		return PistonBehavior.BLOCK;
+	}
+}

--- a/src/main/java/com/brand/blockus/content/StonesRelated.java
+++ b/src/main/java/com/brand/blockus/content/StonesRelated.java
@@ -2,6 +2,7 @@ package com.brand.blockus.content;
 
 import com.brand.blockus.Blockus;
 import com.brand.blockus.blocks.SmoothStoneStairsBlock;
+import com.brand.blockus.blocks.SturdyStoneBlock;
 import com.brand.blockus.blocks.Base.BlockBase;
 import com.brand.blockus.blocks.Base.DoorBase;
 import com.brand.blockus.blocks.Base.GlazedLikeBlockBase;
@@ -70,4 +71,7 @@ public class StonesRelated {
 	public static final WallBase WARPED_WARTY_BLACKSTONE_BRICKS_WALL = new WallBase("warped_warty_blackstone_bricks_wall", WARPED_WARTY_BLACKSTONE_BRICKS);
 	public static final StairsBase WARPED_WARTY_BLACKSTONE_BRICKS_STAIRS = new StairsBase(WARPED_WARTY_BLACKSTONE_BRICKS.getDefaultState(), "warped_warty_blackstone_bricks_stairs", WARPED_WARTY_BLACKSTONE_BRICKS);
 	public static final SlabBase WARPED_WARTY_BLACKSTONE_BRICKS_SLAB = new SlabBase("warped_warty_blackstone_bricks_slab", WARPED_WARTY_BLACKSTONE_BRICKS);
+
+	// sturdy stone
+	public static final SturdyStoneBlock STURDY_STONE = new SturdyStoneBlock("sturdy_stone");
   }

--- a/src/main/resources/assets/blockus/blockstates/sturdy_stone.json
+++ b/src/main/resources/assets/blockus/blockstates/sturdy_stone.json
@@ -1,0 +1,5 @@
+{
+    "variants": {
+        "": { "model": "blockus:block/sturdy_stone" }
+    }
+}

--- a/src/main/resources/assets/blockus/lang/en_us.json
+++ b/src/main/resources/assets/blockus/lang/en_us.json
@@ -668,6 +668,8 @@
 	"block.blockus.thatch_slab": "Thatch Slab",
 	"block.blockus.iron_plating": "Iron Plating",
 	"block.blockus.dirt_path": "Dirt Path",	
+
+	"block.blockus.sturdy_stone": "Sturdy Stone",
 	
 	"block.minecraft.nether_wart_block": "Crimson Wart Block",
 	

--- a/src/main/resources/assets/blockus/models/block/sturdy_stone.json
+++ b/src/main/resources/assets/blockus/models/block/sturdy_stone.json
@@ -1,0 +1,6 @@
+{
+    "parent": "block/cube_all",
+    "textures": {
+        "all": "block/furnace_top"
+    }
+}

--- a/src/main/resources/assets/blockus/models/item/sturdy_stone.json
+++ b/src/main/resources/assets/blockus/models/item/sturdy_stone.json
@@ -1,0 +1,3 @@
+{
+    "parent": "blockus:block/sturdy_stone"
+}

--- a/src/main/resources/data/blockus/loot_tables/blocks/sturdy_stone.json
+++ b/src/main/resources/data/blockus/loot_tables/blocks/sturdy_stone.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "blockus:sturdy_stone"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/blockus/recipes/sturdy_stone.json
+++ b/src/main/resources/data/blockus/recipes/sturdy_stone.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "sturdy stone",
+  "pattern": [
+    "CSC",
+    "S S",
+    "CSC"
+  ],
+  "key": {
+    "C": {
+      "item": "minecraft:cobblestone"
+    },
+    "S": {
+      "item": "minecraft:stone"
+    }
+  },
+  "result": {
+    "item": "blockus:sturdy_stone"
+  }
+} 

--- a/src/main/resources/data/blockus/recipes/sturdy_stone_alternate.json
+++ b/src/main/resources/data/blockus/recipes/sturdy_stone_alternate.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "sturdy stone",
+  "pattern": [
+    "SCS",
+    "C C",
+    "SCS"
+  ],
+  "key": {
+    "S": {
+      "item": "minecraft:stone"
+    },
+    "C": {
+      "item": "minecraft:cobblestone"
+    }
+  },
+  "result": {
+    "item": "blockus:sturdy_stone"
+  }
+} 


### PR DESCRIPTION
This pull request adds sturdy stone, which acts like regular stone except it cannot be moved by pistons. It is crafted by 4 cobblestone and 4 stone in a ring shape.

![Sturdy stone above a powered piston](https://user-images.githubusercontent.com/24855774/89114897-2bc42080-d44f-11ea-9bde-22e7dc83e772.png)
