### PR TITLE
Add color provider to white oak leaves.

### DIFF
--- a/src/main/java/com/brand/blockus/BlockusClient.java
+++ b/src/main/java/com/brand/blockus/BlockusClient.java
@@ -14,6 +14,7 @@ public class BlockusClient implements ClientModInitializer {
 
     @Override
     public void onInitializeClient() {
+        ColorProviderRegistry.BLOCK.register((state, world, pos, tintIndex) -> 0xffebb359, BlockusBlocks.WHITE_OAK_LEAVES, BlockusBlocks.WHITE_OAK_SMALL_HEDGE);
 
         registerBlockColor(BlockusBlocks.OAK_SMALL_HEDGE, Blocks.OAK_LEAVES);
         registerBlockColor(BlockusBlocks.SPRUCE_SMALL_HEDGE, Blocks.SPRUCE_LEAVES);

--- a/src/main/resources/assets/blockus/models/block/white_oak_leaves.json
+++ b/src/main/resources/assets/blockus/models/block/white_oak_leaves.json
@@ -2,5 +2,19 @@
   "parent": "minecraft:block/leaves",
   "textures": {
     "all": "blockus:block/white_oak_leaves"
-  }
+  },
+  "elements": [
+    {
+      "from": [ 0, 0, 0 ],
+      "to": [ 16, 16, 16 ],
+      "faces": {
+        "down":  { "uv": [ 0, 0, 16, 16 ], "texture": "#all", "cullface": "down" },
+        "up":    { "uv": [ 0, 0, 16, 16 ], "texture": "#all", "cullface": "up" },
+        "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#all", "cullface": "north" },
+        "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#all", "cullface": "south" },
+        "west":  { "uv": [ 0, 0, 16, 16 ], "texture": "#all", "cullface": "west" },
+        "east":  { "uv": [ 0, 0, 16, 16 ], "texture": "#all", "cullface": "east" }
+      }
+    }
+  ]
 }

--- a/src/main/resources/assets/blockus/models/block/white_oak_small_hedge_end.json
+++ b/src/main/resources/assets/blockus/models/block/white_oak_small_hedge_end.json
@@ -1,6 +1,21 @@
 {
-    "parent": "blockus:block/template_small_hedge_end",
-    "textures": {
-        "hedge": "blockus:block/white_oak_leaves"
+  "parent": "blockus:block/template_small_hedge_end",
+  "textures": {
+    "hedge": "blockus:block/white_oak_leaves"
+  },
+  "elements": [
+    {
+      "from": [ 5, 0, 5 ],
+      "to": [ 11, 16, 11 ],
+      "faces": {
+        "down":  { "texture": "#hedge", "cullface": "down" },
+        "up":    { "texture": "#hedge", "cullface": "up" },
+        "north": { "texture": "#hedge" },
+        "south": { "texture": "#hedge" },
+        "west":  { "texture": "#hedge" },
+        "east":  { "texture": "#hedge" }
+      },
+      "__comment": "Hedge end"
     }
+  ]
 }

--- a/src/main/resources/assets/blockus/models/block/white_oak_small_hedge_side.json
+++ b/src/main/resources/assets/blockus/models/block/white_oak_small_hedge_side.json
@@ -1,6 +1,21 @@
 {
-    "parent": "blockus:block/template_small_hedge_side",
-    "textures": {
-        "hedge": "blockus:block/white_oak_leaves"
+  "parent": "blockus:block/template_small_hedge_side",
+  "textures": {
+    "hedge": "blockus:block/white_oak_leaves"
+  },
+  "elements": [
+    {
+      "from": [ 5, 0, 0 ],
+      "to": [ 11, 16, 8 ],
+      "faces": {
+        "down":  { "texture": "#hedge", "cullface": "down" },
+        "up":    { "texture": "#hedge" },
+        "north": { "texture": "#hedge", "cullface": "north" },
+        "south": { "texture": "#hedge", "cullface": "south" },
+        "west":  { "texture": "#hedge" },
+        "east":  { "texture": "#hedge" }
+      },
+      "__comment": "hedge"
     }
+  ]
 }

--- a/src/main/resources/assets/blockus/models/block/white_oak_small_hedge_side_tall.json
+++ b/src/main/resources/assets/blockus/models/block/white_oak_small_hedge_side_tall.json
@@ -1,6 +1,21 @@
 {
-    "parent": "blockus:block/template_small_hedge_side_tall",
-    "textures": {
-        "hedge": "blockus:block/white_oak_leaves"
+  "parent": "blockus:block/template_small_hedge_side_tall",
+  "textures": {
+    "hedge": "blockus:block/white_oak_leaves"
+  },
+  "elements": [
+    {
+      "from": [ 5, 0, 0 ],
+      "to": [ 11, 16, 8 ],
+      "faces": {
+        "down":  { "texture": "#hedge", "cullface": "down" },
+        "up":    { "texture": "#hedge" },
+        "north": { "texture": "#hedge", "cullface": "north" },
+        "south": { "texture": "#hedge", "cullface": "south" },
+        "west":  { "texture": "#hedge" },
+        "east":  { "texture": "#hedge" }
+      },
+      "__comment": "hedge"
     }
+  ]
 }


### PR DESCRIPTION
White oak leaves (and small hedge) do not have a color provider.

Which causes some issues with mods like falling leaves or my upcoming LambdaMap mod.

Here's the issue in action:
![image](https://user-images.githubusercontent.com/12587332/105990093-4f84be00-60a2-11eb-9388-b1cf029a0638.png)

As there's no color provider it defaults to white.

This PR aims at adding the color provider to solve this issue, and I modified the models of white oak leaves and small hedge to not use the tint index as it would color the texture incorrectly as it's not a gray scale texture.