### PR TITLE
Allow wandering traders to sell white oak saplings

### DIFF
--- a/src/main/java/com/brand/blockus/Instance.java
+++ b/src/main/java/com/brand/blockus/Instance.java
@@ -1,15 +1,23 @@
 package com.brand.blockus;
 
 import com.brand.blockus.content.BlockusBlocks;
+
+import net.fabricmc.fabric.api.object.builder.v1.trade.TradeOfferHelper;
 import net.fabricmc.fabric.api.registry.CompostingChanceRegistry;
 import net.fabricmc.fabric.api.registry.FlammableBlockRegistry;
 import net.fabricmc.fabric.api.registry.FuelRegistry;
 import net.minecraft.block.Blocks;
+import net.minecraft.entity.Entity;
 import net.minecraft.item.AxeItem;
+import net.minecraft.item.ItemConvertible;
+import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.item.ShovelItem;
+import net.minecraft.village.TradeOffer;
+import net.minecraft.village.TradeOffers;
 
 import java.util.HashMap;
+import java.util.Random;
 
 public class Instance {
 
@@ -231,10 +239,16 @@ public class Instance {
 
 // Instance
 
+       addTradeOffers();
         addStrippables();
         addPathBlocks();
     }
 
+    public static void addTradeOffers() {
+        TradeOfferHelper.registerWanderingTraderOffers(1, factories -> {
+            factories.add(new SellSaplingFactory(BlockusBlocks.WHITE_OAK_SAPLING_ITEM));
+        });
+    }
 
     public static void addStrippables() {
         AxeItem.STRIPPED_BLOCKS = new HashMap<>(AxeItem.STRIPPED_BLOCKS);
@@ -247,5 +261,17 @@ public class Instance {
         ShovelItem.PATH_STATES.put(Blocks.DIRT, BlockusBlocks.PATH.getDefaultState());
         ShovelItem.PATH_STATES.put(Blocks.COARSE_DIRT, BlockusBlocks.PATH.getDefaultState());
         ShovelItem.PATH_STATES.put(Blocks.GRASS_PATH, BlockusBlocks.PATH.getDefaultState());
+    }
+
+    private static class SellSaplingFactory implements TradeOffers.Factory {
+        private final ItemStack sapling;
+
+        public SellSaplingFactory(ItemConvertible sapling) {
+            this.sapling = new ItemStack(sapling);
+        }
+
+        public TradeOffer create(Entity entity, Random random) {
+            return new TradeOffer(new ItemStack(Items.EMERALD, 5), this.sapling, 8, 1, 0.05f);
+        }
     }
 }

--- a/src/main/java/com/brand/blockus/content/BlocksRegistration.java
+++ b/src/main/java/com/brand/blockus/content/BlocksRegistration.java
@@ -313,9 +313,14 @@ public class BlocksRegistration {
         Identifier identifier = new Identifier(Blockus.MOD_ID, id);
         Block registeredBlock = Registry.register(Registry.BLOCK, identifier, block);
         if (registerItem) {
-            Registry.register(Registry.ITEM, identifier, new BlockItem(registeredBlock, new Item.Settings().maxCount(64).group(Blockus.BLOCKUS_DECORATIONS)));
+            register_decoration_item(id, registeredBlock);
         }
         return registeredBlock;
+    }
+
+    public static Item register_decoration_item(String id, Block block) {
+        Identifier identifier = new Identifier(Blockus.MOD_ID, id);
+        return Registry.register(Registry.ITEM, identifier, new BlockItem(block, new Item.Settings().maxCount(64).group(Blockus.BLOCKUS_DECORATIONS)));
     }
 
     public static Block register_decoration(String id, Block block) {

--- a/src/main/java/com/brand/blockus/content/BlockusBlocks.java
+++ b/src/main/java/com/brand/blockus/content/BlockusBlocks.java
@@ -11,6 +11,7 @@ import net.fabricmc.fabric.api.tool.attribute.v1.FabricToolTags;
 import net.minecraft.block.*;
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.block.entity.BlockEntityType;
+import net.minecraft.item.Item;
 import net.minecraft.sound.BlockSoundGroup;
 import net.minecraft.util.DyeColor;
 import net.minecraft.util.Identifier;
@@ -356,7 +357,8 @@ public class BlockusBlocks extends BlocksRegistration {
     public static final Block CHARRED_TRAPDOOR = registerTrapdoor("charred", 2.0f, 3.0f, Material.WOOD, BlockSoundGroup.WOOD, FabricToolTags.AXES, 0, CHARRED_PLANKS.getDefaultMaterialColor());
 
     // White Oak Wood
-    public static final Block WHITE_OAK_SAPLING = register_decoration("white_oak_sapling", new SaplingBlockBase(new WhiteOakSaplingGenerator(), FabricBlockSettings.copy(Blocks.OAK_SAPLING)));
+    public static final Block WHITE_OAK_SAPLING = register_decoration("white_oak_sapling", new SaplingBlockBase(new WhiteOakSaplingGenerator(), FabricBlockSettings.copy(Blocks.OAK_SAPLING)), false);
+    public static final Item WHITE_OAK_SAPLING_ITEM = register_decoration_item("white_oak_sapling", WHITE_OAK_SAPLING);
     public static final Block POTTED_WHITE_OAK_SAPLING = registerPottedPlant(WHITE_OAK_SAPLING, "white_oak_sapling");
     public static final Block WHITE_OAK_LOG = register("white_oak_log", new PillarBlock(FabricBlockSettings.copyOf(Blocks.OAK_LOG).materialColor(MaterialColor.LIGHT_GRAY_TERRACOTTA)));
     public static final Block STRIPPED_WHITE_OAK_LOG = registerPillar2("stripped_white_oak_log", WHITE_OAK_LOG);


### PR DESCRIPTION
This pull request adds the ability for wandering traders to sell white oak saplings, just like they would with any other sapling.

![Wandering trader selling white oak sapling](https://user-images.githubusercontent.com/24855774/114716969-94fc7300-9d02-11eb-8c0f-a59dac32ef00.png)
