### PR TITLE
Add wooden hoppers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,9 @@ dependencies {
 
 	// Columns
 	modImplementation "curse.maven:columns-385230:3107117"
+
+	// Wooden Hoppers
+	modImplementation "curse.maven:woodenhoppers-406021:3048188"
 }
 
 minecraft {

--- a/src/main/java/com/brand/blockus/Blockus.java
+++ b/src/main/java/com/brand/blockus/Blockus.java
@@ -1,8 +1,9 @@
 package com.brand.blockus;
 
 import com.brand.blockus.content.BlockusBlocks;
-import com.brand.blockus.content.BlockusColumnBlocks;
 import com.brand.blockus.content.BlockusItems;
+import com.brand.blockus.content.compatibility.BlockusColumnBlocks;
+import com.brand.blockus.content.compatibility.BlockusWoodenHopperBlocks;
 import com.brand.blockus.world.BlockusConfiguredFeatures;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.client.itemgroup.FabricItemGroupBuilder;
@@ -30,6 +31,10 @@ public class Blockus implements ModInitializer {
 
         if (FabricLoader.getInstance().isModLoaded("columns")) {
             BlockusColumnBlocks.init();
+        }
+
+        if (FabricLoader.getInstance().isModLoaded("woodenhoppers")) {
+            BlockusWoodenHopperBlocks.init();
         }
 
         Instance.init();

--- a/src/main/java/com/brand/blockus/blocks/compatibility/BlockusWoodenHopperBlock.java
+++ b/src/main/java/com/brand/blockus/blocks/compatibility/BlockusWoodenHopperBlock.java
@@ -1,0 +1,16 @@
+package com.brand.blockus.blocks.compatibility;
+
+import io.github.haykam821.woodenhoppers.block.WoodenHopperBlock;
+import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.world.BlockView;
+
+public class BlockusWoodenHopperBlock extends WoodenHopperBlock {
+    public BlockusWoodenHopperBlock(Settings settings) {
+        super(settings);
+    }
+    
+    @Override
+    public BlockEntity createBlockEntity(BlockView world) {
+        return new BlockusWoodenHopperBlockEntity();
+    }
+}

--- a/src/main/java/com/brand/blockus/blocks/compatibility/BlockusWoodenHopperBlockEntity.java
+++ b/src/main/java/com/brand/blockus/blocks/compatibility/BlockusWoodenHopperBlockEntity.java
@@ -1,0 +1,13 @@
+package com.brand.blockus.blocks.compatibility;
+
+import com.brand.blockus.content.compatibility.BlockusWoodenHopperBlocks;
+
+import io.github.haykam821.woodenhoppers.block.entity.WoodenHopperBlockEntity;
+import net.minecraft.block.entity.BlockEntityType;
+
+public class BlockusWoodenHopperBlockEntity extends WoodenHopperBlockEntity {
+    @Override
+    public BlockEntityType<?> getType() {
+        return BlockusWoodenHopperBlocks.BLOCK_ENTITY_TYPE;
+    }
+}

--- a/src/main/java/com/brand/blockus/content/compatibility/BlockusColumnBlocks.java
+++ b/src/main/java/com/brand/blockus/content/compatibility/BlockusColumnBlocks.java
@@ -1,6 +1,7 @@
-package com.brand.blockus.content;
+package com.brand.blockus.content.compatibility;
 
 import com.brand.blockus.Blockus;
+import com.brand.blockus.content.BlockusBlocks;
 
 import io.github.haykam821.columns.block.ColumnBlock;
 import net.fabricmc.fabric.api.object.builder.v1.block.FabricBlockSettings;

--- a/src/main/java/com/brand/blockus/content/compatibility/BlockusWoodenHopperBlocks.java
+++ b/src/main/java/com/brand/blockus/content/compatibility/BlockusWoodenHopperBlocks.java
@@ -1,0 +1,45 @@
+package com.brand.blockus.content.compatibility;
+
+import com.brand.blockus.Blockus;
+import com.brand.blockus.blocks.compatibility.BlockusWoodenHopperBlock;
+import com.brand.blockus.content.BlockusBlocks;
+
+import io.github.haykam821.woodenhoppers.block.entity.WoodenHopperBlockEntity;
+import net.fabricmc.fabric.api.object.builder.v1.block.FabricBlockSettings;
+import net.minecraft.block.Block;
+import net.minecraft.block.Material;
+import net.minecraft.block.entity.BlockEntityType;
+import net.minecraft.item.BlockItem;
+import net.minecraft.item.Item;
+import net.minecraft.sound.BlockSoundGroup;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.registry.Registry;
+
+public final class BlockusWoodenHopperBlocks {
+    private static final Block BAMBOO_HOPPER = registerHopperBlockAndItem("bamboo_hopper", BlockusBlocks.BAMBOO_PLANKS);
+
+    private static final Identifier BLOCK_ENTITY_TYPE_ID = new Identifier(Blockus.MOD_ID, "wooden_hopper");
+    public static final BlockEntityType<WoodenHopperBlockEntity> BLOCK_ENTITY_TYPE = BlockEntityType.Builder
+        .create(WoodenHopperBlockEntity::new, BAMBOO_HOPPER)
+        .build(null);
+
+    private BlockusWoodenHopperBlocks() {
+        return;
+    }
+
+    private static Block registerHopperBlockAndItem(String path, Block base) {
+        Identifier id = new Identifier(Blockus.MOD_ID, path);
+
+        Block block = new BlockusWoodenHopperBlock(FabricBlockSettings.of(Material.WOOD, base.getDefaultMaterialColor()).strength(2).sounds(BlockSoundGroup.WOOD).nonOpaque());
+        Registry.register(Registry.BLOCK, id, block);
+
+        Item item = new BlockItem(block, new Item.Settings().group(Blockus.BLOCKUS_REDSTONE));
+        Registry.register(Registry.ITEM, id, item);
+
+        return block;
+    }
+
+    public static void init() {
+        Registry.register(Registry.BLOCK_ENTITY_TYPE, BLOCK_ENTITY_TYPE_ID, BLOCK_ENTITY_TYPE);
+    }
+}

--- a/src/main/java/com/brand/blockus/content/compatibility/BlockusWoodenHopperBlocks.java
+++ b/src/main/java/com/brand/blockus/content/compatibility/BlockusWoodenHopperBlocks.java
@@ -18,10 +18,11 @@ import net.minecraft.util.registry.Registry;
 public final class BlockusWoodenHopperBlocks {
     private static final Block BAMBOO_HOPPER = registerHopperBlockAndItem("bamboo_hopper", BlockusBlocks.BAMBOO_PLANKS);
     private static final Block CHARRED_HOPPER = registerHopperBlockAndItem("charred_hopper", BlockusBlocks.CHARRED_PLANKS);
+    private static final Block WHITE_OAK_HOPPER = registerHopperBlockAndItem("white_oak_hopper", BlockusBlocks.WHITE_OAK_PLANKS);
 
     private static final Identifier BLOCK_ENTITY_TYPE_ID = new Identifier(Blockus.MOD_ID, "wooden_hopper");
     public static final BlockEntityType<WoodenHopperBlockEntity> BLOCK_ENTITY_TYPE = BlockEntityType.Builder
-        .create(WoodenHopperBlockEntity::new, BAMBOO_HOPPER, CHARRED_HOPPER)
+        .create(WoodenHopperBlockEntity::new, BAMBOO_HOPPER, CHARRED_HOPPER, WHITE_OAK_HOPPER)
         .build(null);
 
     private BlockusWoodenHopperBlocks() {

--- a/src/main/java/com/brand/blockus/content/compatibility/BlockusWoodenHopperBlocks.java
+++ b/src/main/java/com/brand/blockus/content/compatibility/BlockusWoodenHopperBlocks.java
@@ -17,10 +17,11 @@ import net.minecraft.util.registry.Registry;
 
 public final class BlockusWoodenHopperBlocks {
     private static final Block BAMBOO_HOPPER = registerHopperBlockAndItem("bamboo_hopper", BlockusBlocks.BAMBOO_PLANKS);
+    private static final Block CHARRED_HOPPER = registerHopperBlockAndItem("charred_hopper", BlockusBlocks.CHARRED_PLANKS);
 
     private static final Identifier BLOCK_ENTITY_TYPE_ID = new Identifier(Blockus.MOD_ID, "wooden_hopper");
     public static final BlockEntityType<WoodenHopperBlockEntity> BLOCK_ENTITY_TYPE = BlockEntityType.Builder
-        .create(WoodenHopperBlockEntity::new, BAMBOO_HOPPER)
+        .create(WoodenHopperBlockEntity::new, BAMBOO_HOPPER, CHARRED_HOPPER)
         .build(null);
 
     private BlockusWoodenHopperBlocks() {

--- a/src/main/resources/assets/blockus/blockstates/bamboo_hopper.json
+++ b/src/main/resources/assets/blockus/blockstates/bamboo_hopper.json
@@ -1,0 +1,22 @@
+{
+    "variants": {
+        "facing=down": {
+            "model": "blockus:block/bamboo_hopper"
+        },
+        "facing=east": {
+            "model": "blockus:block/bamboo_hopper_side",
+            "y": 90
+        },
+        "facing=north": {
+            "model": "blockus:block/bamboo_hopper_side"
+        },
+        "facing=south": {
+            "model": "blockus:block/bamboo_hopper_side",
+            "y": 180
+        },
+        "facing=west": {
+            "model": "blockus:block/bamboo_hopper_side",
+            "y": 270
+        }
+    }
+}

--- a/src/main/resources/assets/blockus/blockstates/charred_hopper.json
+++ b/src/main/resources/assets/blockus/blockstates/charred_hopper.json
@@ -1,0 +1,22 @@
+{
+    "variants": {
+        "facing=down": {
+            "model": "blockus:block/charred_hopper"
+        },
+        "facing=east": {
+            "model": "blockus:block/charred_hopper_side",
+            "y": 90
+        },
+        "facing=north": {
+            "model": "blockus:block/charred_hopper_side"
+        },
+        "facing=south": {
+            "model": "blockus:block/charred_hopper_side",
+            "y": 180
+        },
+        "facing=west": {
+            "model": "blockus:block/charred_hopper_side",
+            "y": 270
+        }
+    }
+}

--- a/src/main/resources/assets/blockus/blockstates/white_oak_hopper.json
+++ b/src/main/resources/assets/blockus/blockstates/white_oak_hopper.json
@@ -1,0 +1,22 @@
+{
+    "variants": {
+        "facing=down": {
+            "model": "blockus:block/white_oak_hopper"
+        },
+        "facing=east": {
+            "model": "blockus:block/white_oak_hopper_side",
+            "y": 90
+        },
+        "facing=north": {
+            "model": "blockus:block/white_oak_hopper_side"
+        },
+        "facing=south": {
+            "model": "blockus:block/white_oak_hopper_side",
+            "y": 180
+        },
+        "facing=west": {
+            "model": "blockus:block/white_oak_hopper_side",
+            "y": 270
+        }
+    }
+}

--- a/src/main/resources/assets/blockus/lang/en_us.json
+++ b/src/main/resources/assets/blockus/lang/en_us.json
@@ -865,5 +865,6 @@
   "block.blockus.rainbow_brick_column": "Rainbow Brick Column",
 
   "block.blockus.bamboo_hopper": "Bamboo Hopper",
-  "block.blockus.charred_hopper": "Charred Hopper"
+  "block.blockus.charred_hopper": "Charred Hopper",
+  "block.blockus.white_oak_hopper": "White Oak Hopper"
 }

--- a/src/main/resources/assets/blockus/lang/en_us.json
+++ b/src/main/resources/assets/blockus/lang/en_us.json
@@ -862,5 +862,7 @@
   "block.blockus.honeycomb_brick_column": "Honeycomb Brick Column",
   "block.blockus.purpur_brick_column": "Purpur Brick Column",
   "block.blockus.phantom_purpur_brick_column": "Phantom Purpur Brick Column",
-  "block.blockus.rainbow_brick_column": "Rainbow Brick Column"
+  "block.blockus.rainbow_brick_column": "Rainbow Brick Column",
+
+  "block.blockus.bamboo_hopper": "Bamboo Hopper"
 }

--- a/src/main/resources/assets/blockus/lang/en_us.json
+++ b/src/main/resources/assets/blockus/lang/en_us.json
@@ -864,5 +864,6 @@
   "block.blockus.phantom_purpur_brick_column": "Phantom Purpur Brick Column",
   "block.blockus.rainbow_brick_column": "Rainbow Brick Column",
 
-  "block.blockus.bamboo_hopper": "Bamboo Hopper"
+  "block.blockus.bamboo_hopper": "Bamboo Hopper",
+  "block.blockus.charred_hopper": "Charred Hopper"
 }

--- a/src/main/resources/assets/blockus/models/block/bamboo_hopper.json
+++ b/src/main/resources/assets/blockus/models/block/bamboo_hopper.json
@@ -1,0 +1,6 @@
+{
+    "parent": "woodenhoppers:block/wooden_hopper",
+    "textures": {
+        "all": "blockus:block/bamboo_planks"
+    }
+}

--- a/src/main/resources/assets/blockus/models/block/bamboo_hopper_side.json
+++ b/src/main/resources/assets/blockus/models/block/bamboo_hopper_side.json
@@ -1,0 +1,9 @@
+{
+    "parent": "block/hopper_side",
+    "textures": {
+        "particle": "blockus:block/bamboo_planks",
+        "top": "blockus:block/bamboo_planks",
+        "side": "blockus:block/bamboo_planks",
+        "inside": "blockus:block/bamboo_planks"
+    }
+}

--- a/src/main/resources/assets/blockus/models/block/charred_hopper.json
+++ b/src/main/resources/assets/blockus/models/block/charred_hopper.json
@@ -1,0 +1,6 @@
+{
+    "parent": "woodenhoppers:block/wooden_hopper",
+    "textures": {
+        "all": "blockus:block/charred_planks"
+    }
+}

--- a/src/main/resources/assets/blockus/models/block/charred_hopper_side.json
+++ b/src/main/resources/assets/blockus/models/block/charred_hopper_side.json
@@ -1,0 +1,9 @@
+{
+    "parent": "block/hopper_side",
+    "textures": {
+        "particle": "blockus:block/charred_planks",
+        "top": "blockus:block/charred_planks",
+        "side": "blockus:block/charred_planks",
+        "inside": "blockus:block/charred_planks"
+    }
+}

--- a/src/main/resources/assets/blockus/models/block/white_oak_hopper.json
+++ b/src/main/resources/assets/blockus/models/block/white_oak_hopper.json
@@ -1,0 +1,6 @@
+{
+    "parent": "woodenhoppers:block/wooden_hopper",
+    "textures": {
+        "all": "blockus:block/white_oak_planks"
+    }
+}

--- a/src/main/resources/assets/blockus/models/block/white_oak_hopper_side.json
+++ b/src/main/resources/assets/blockus/models/block/white_oak_hopper_side.json
@@ -1,0 +1,9 @@
+{
+    "parent": "block/hopper_side",
+    "textures": {
+        "particle": "blockus:block/white_oak_planks",
+        "top": "blockus:block/white_oak_planks",
+        "side": "blockus:block/white_oak_planks",
+        "inside": "blockus:block/white_oak_planks"
+    }
+}

--- a/src/main/resources/assets/blockus/models/item/bamboo_hopper.json
+++ b/src/main/resources/assets/blockus/models/item/bamboo_hopper.json
@@ -1,0 +1,3 @@
+{
+    "parent": "blockus:block/bamboo_hopper"
+}

--- a/src/main/resources/assets/blockus/models/item/charred_hopper.json
+++ b/src/main/resources/assets/blockus/models/item/charred_hopper.json
@@ -1,0 +1,3 @@
+{
+    "parent": "blockus:block/charred_hopper"
+}

--- a/src/main/resources/assets/blockus/models/item/white_oak_hopper.json
+++ b/src/main/resources/assets/blockus/models/item/white_oak_hopper.json
@@ -1,0 +1,3 @@
+{
+    "parent": "blockus:block/white_oak_hopper"
+}

--- a/src/main/resources/data/blockus/advancements/recipes/bamboo_hopper.json
+++ b/src/main/resources/data/blockus/advancements/recipes/bamboo_hopper.json
@@ -1,0 +1,32 @@
+{
+    "parent": "minecraft:recipes/root",
+    "rewards": {
+        "recipes": [
+            "blockus:bamboo_hopper"
+        ]
+    },
+    "criteria": {
+        "has_bamboo_planks": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+                "items": [
+                    {
+                        "item": "blockus:bamboo_planks"
+                    }
+                ]
+            }
+        },
+        "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+                "recipe": "blockus:bamboo_hopper"
+            }
+        }
+    },
+    "requirements": [
+        [
+            "has_bamboo_planks",
+            "has_the_recipe"
+        ]
+    ]
+}

--- a/src/main/resources/data/blockus/advancements/recipes/charred_hopper.json
+++ b/src/main/resources/data/blockus/advancements/recipes/charred_hopper.json
@@ -1,0 +1,32 @@
+{
+    "parent": "minecraft:recipes/root",
+    "rewards": {
+        "recipes": [
+            "blockus:charred_hopper"
+        ]
+    },
+    "criteria": {
+        "has_charred_planks": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+                "items": [
+                    {
+                        "item": "blockus:charred_planks"
+                    }
+                ]
+            }
+        },
+        "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+                "recipe": "blockus:charred_hopper"
+            }
+        }
+    },
+    "requirements": [
+        [
+            "has_charred_planks",
+            "has_the_recipe"
+        ]
+    ]
+}

--- a/src/main/resources/data/blockus/advancements/recipes/white_oak_hopper.json
+++ b/src/main/resources/data/blockus/advancements/recipes/white_oak_hopper.json
@@ -1,0 +1,32 @@
+{
+    "parent": "minecraft:recipes/root",
+    "rewards": {
+        "recipes": [
+            "blockus:white_oak_hopper"
+        ]
+    },
+    "criteria": {
+        "has_white_oak_planks": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+                "items": [
+                    {
+                        "item": "blockus:white_oak_planks"
+                    }
+                ]
+            }
+        },
+        "has_the_recipe": {
+            "trigger": "minecraft:recipe_unlocked",
+            "conditions": {
+                "recipe": "blockus:white_oak_hopper"
+            }
+        }
+    },
+    "requirements": [
+        [
+            "has_white_oak_planks",
+            "has_the_recipe"
+        ]
+    ]
+}

--- a/src/main/resources/data/blockus/loot_tables/blocks/bamboo_hopper.json
+++ b/src/main/resources/data/blockus/loot_tables/blocks/bamboo_hopper.json
@@ -1,0 +1,25 @@
+{
+    "type": "minecraft:block",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:item",
+                    "functions": [
+                        {
+                            "function": "minecraft:copy_name",
+                            "source": "block_entity"
+                        }
+                    ],
+                    "name": "blockus:bamboo_hopper"
+                }
+            ],
+            "conditions": [
+                {
+                    "condition": "minecraft:survives_explosion"
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/data/blockus/loot_tables/blocks/charred_hopper.json
+++ b/src/main/resources/data/blockus/loot_tables/blocks/charred_hopper.json
@@ -1,0 +1,25 @@
+{
+    "type": "minecraft:block",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:item",
+                    "functions": [
+                        {
+                            "function": "minecraft:copy_name",
+                            "source": "block_entity"
+                        }
+                    ],
+                    "name": "blockus:charred_hopper"
+                }
+            ],
+            "conditions": [
+                {
+                    "condition": "minecraft:survives_explosion"
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/data/blockus/loot_tables/blocks/white_oak_hopper.json
+++ b/src/main/resources/data/blockus/loot_tables/blocks/white_oak_hopper.json
@@ -1,0 +1,25 @@
+{
+    "type": "minecraft:block",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:item",
+                    "functions": [
+                        {
+                            "function": "minecraft:copy_name",
+                            "source": "block_entity"
+                        }
+                    ],
+                    "name": "blockus:white_oak_hopper"
+                }
+            ],
+            "conditions": [
+                {
+                    "condition": "minecraft:survives_explosion"
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/data/blockus/recipes/bamboo_hopper.json
+++ b/src/main/resources/data/blockus/recipes/bamboo_hopper.json
@@ -1,0 +1,20 @@
+{
+    "type": "minecraft:crafting_shaped",
+    "group": "woodenhoppers:wooden_hopper",
+    "pattern": [
+        "b b",
+        "bCb",
+        " b "
+    ],
+    "key": {
+        "C": {
+            "item": "minecraft:chest"
+        },
+        "b": {
+            "item": "blockus:bamboo_planks"
+        }
+    },
+    "result": {
+        "item": "blockus:bamboo_hopper"
+    }
+}

--- a/src/main/resources/data/blockus/recipes/charred_hopper.json
+++ b/src/main/resources/data/blockus/recipes/charred_hopper.json
@@ -1,0 +1,20 @@
+{
+    "type": "minecraft:crafting_shaped",
+    "group": "woodenhoppers:wooden_hopper",
+    "pattern": [
+        "c c",
+        "cCc",
+        " c "
+    ],
+    "key": {
+        "C": {
+            "item": "minecraft:chest"
+        },
+        "c": {
+            "item": "blockus:charred_planks"
+        }
+    },
+    "result": {
+        "item": "blockus:charred_hopper"
+    }
+}

--- a/src/main/resources/data/blockus/recipes/white_oak_hopper.json
+++ b/src/main/resources/data/blockus/recipes/white_oak_hopper.json
@@ -1,0 +1,20 @@
+{
+    "type": "minecraft:crafting_shaped",
+    "group": "woodenhoppers:wooden_hopper",
+    "pattern": [
+        "w w",
+        "wCw",
+        " w "
+    ],
+    "key": {
+        "C": {
+            "item": "minecraft:chest"
+        },
+        "w": {
+            "item": "blockus:white_oak_planks"
+        }
+    },
+    "result": {
+        "item": "blockus:white_oak_hopper"
+    }
+}

--- a/src/main/resources/data/woodenhoppers/tags/blocks/wooden_hoppers.json
+++ b/src/main/resources/data/woodenhoppers/tags/blocks/wooden_hoppers.json
@@ -7,7 +7,8 @@
           "libcd:mod_loaded": "woodenhoppers"
         },
         "values": [
-          "blockus:bamboo_hopper"
+          "blockus:bamboo_hopper",
+          "blockus:charred_hopper"
         ]
       }
     ]

--- a/src/main/resources/data/woodenhoppers/tags/blocks/wooden_hoppers.json
+++ b/src/main/resources/data/woodenhoppers/tags/blocks/wooden_hoppers.json
@@ -1,0 +1,15 @@
+{
+  "values": [],
+  "libcd": {
+    "entries": [
+      {
+        "when": {
+          "libcd:mod_loaded": "woodenhoppers"
+        },
+        "values": [
+          "blockus:bamboo_hopper"
+        ]
+      }
+    ]
+  }
+}

--- a/src/main/resources/data/woodenhoppers/tags/blocks/wooden_hoppers.json
+++ b/src/main/resources/data/woodenhoppers/tags/blocks/wooden_hoppers.json
@@ -8,7 +8,8 @@
         },
         "values": [
           "blockus:bamboo_hopper",
-          "blockus:charred_hopper"
+          "blockus:charred_hopper",
+          "blockus:white_oak_hopper"
         ]
       }
     ]

--- a/src/main/resources/data/woodenhoppers/tags/items/wooden_hoppers.json
+++ b/src/main/resources/data/woodenhoppers/tags/items/wooden_hoppers.json
@@ -7,7 +7,8 @@
           "libcd:mod_loaded": "woodenhoppers"
         },
         "values": [
-          "blockus:bamboo_hopper"
+          "blockus:bamboo_hopper",
+          "blockus:charred_hopper"
         ]
       }
     ]

--- a/src/main/resources/data/woodenhoppers/tags/items/wooden_hoppers.json
+++ b/src/main/resources/data/woodenhoppers/tags/items/wooden_hoppers.json
@@ -1,0 +1,15 @@
+{
+  "values": [],
+  "libcd": {
+    "entries": [
+      {
+        "when": {
+          "libcd:mod_loaded": "woodenhoppers"
+        },
+        "values": [
+          "blockus:bamboo_hopper"
+        ]
+      }
+    ]
+  }
+}

--- a/src/main/resources/data/woodenhoppers/tags/items/wooden_hoppers.json
+++ b/src/main/resources/data/woodenhoppers/tags/items/wooden_hoppers.json
@@ -8,7 +8,8 @@
         },
         "values": [
           "blockus:bamboo_hopper",
-          "blockus:charred_hopper"
+          "blockus:charred_hopper",
+          "blockus:white_oak_hopper"
         ]
       }
     ]

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -34,6 +34,7 @@
 	"minecraft": "1.16.x"
   },
   "suggests": {
-    "columns": "*"
+    "columns": "*",
+    "woodenhoppers": "*"
   }
 }


### PR DESCRIPTION
This pull request adds hoppers for all Blockus wood types. These wooden hopper blocks are only registered while the [Wooden Hoppers](https://github.com/haykam821/Wooden-Hoppers) mod is loaded.

![Bamboo, charred, and white oak hoppers](https://user-images.githubusercontent.com/24855774/119078368-0d221c80-b9c4-11eb-970a-7c75e26c13a9.png)
