### PR TITLE
Adding Block/Item Tag for golden_bars/golden_chains

### DIFF
--- a/src/main/generated/data/c/tags/block/bars.json
+++ b/src/main/generated/data/c/tags/block/bars.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "blockus:golden_bars"
+  ]
+}

--- a/src/main/generated/data/c/tags/item/chains.json
+++ b/src/main/generated/data/c/tags/item/chains.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "blockus:golden_chain"
+  ]
+}

--- a/src/main/java/com/brand/blockus/data/providers/BlockusBlockTagProvider.java
+++ b/src/main/java/com/brand/blockus/data/providers/BlockusBlockTagProvider.java
@@ -983,6 +983,9 @@ public class BlockusBlockTagProvider extends FabricTagProvider.BlockTagProvider 
             .add(MOSSY_WHITE_OAK_PLANKS.block)
             .add(MOSSY_RAW_BAMBOO_PLANKS.block);
 
+        this.getOrCreateTagBuilder(Identifier.of("c", "bars"))
+            .add(GOLDEN_BARS);
+
         this.getOrCreateTagBuilder(BlockTags.AXE_MINEABLE)
             .add(LEGACY_PLANKS)
             .add(SOUL_O_LANTERN)

--- a/src/main/java/com/brand/blockus/data/providers/BlockusItemTagProvider.java
+++ b/src/main/java/com/brand/blockus/data/providers/BlockusItemTagProvider.java
@@ -5,6 +5,7 @@ import com.brand.blockus.utils.tags.BlockusBlockTags;
 import com.brand.blockus.utils.tags.BlockusItemTags;
 import net.fabricmc.fabric.api.datagen.v1.FabricDataOutput;
 import net.fabricmc.fabric.api.datagen.v1.provider.FabricTagProvider;
+import net.fabricmc.fabric.api.tag.convention.v2.ConventionalItemTags;
 import net.minecraft.block.Block;
 import net.minecraft.block.Blocks;
 import net.minecraft.item.Item;
@@ -292,5 +293,9 @@ public class BlockusItemTagProvider extends FabricTagProvider.ItemTagProvider {
 //        this.copy(new Identifier("promenade", "dark_amaranth_stems"));
 //
 //        this.copy(new Identifier("promenade", "palm_logs"));
+
+        // Conventional Item Tags
+        this.getOrCreateTagBuilder(ConventionalItemTags.CHAINS)
+            .add(GOLDEN_CHAIN.asItem());
     }
 }


### PR DESCRIPTION
To enhance the mod's functionality and compatibility, (especially with my mod connectible chains :wink: ), I have added the `golden_bars` to the `c:bars` tag, and `golden_chains` to the `c:chains` tag.